### PR TITLE
Fix M_PI related compilation isues on Linux

### DIFF
--- a/common/common.h
+++ b/common/common.h
@@ -1,0 +1,3 @@
+#ifndef M_PI
+    #define M_PI 3.14159265358979323846
+#endif

--- a/decode_ft8.c
+++ b/decode_ft8.c
@@ -11,6 +11,7 @@
 #include "ft8/encode.h"
 #include "ft8/crc.h"
 
+#include "common/common.h"
 #include "common/wave.h"
 #include "common/debug.h"
 #include "fft/kiss_fftr.h"

--- a/gen_ft8.c
+++ b/gen_ft8.c
@@ -4,6 +4,7 @@
 #include <math.h>
 #include <stdbool.h>
 
+#include "common/common.h"
 #include "common/wave.h"
 #include "common/debug.h"
 #include "ft8/pack.h"

--- a/test.c
+++ b/test.c
@@ -10,6 +10,7 @@
 #include "ft8/constants.h"
 
 #include "fft/kiss_fftr.h"
+#include "common/common.h"
 #include "common/debug.h"
 
 #define LOG_LEVEL LOG_INFO


### PR DESCRIPTION
On Ubuntu Linux, I run into the following `M_PI` compilation errors without the patch in this PR.

```
$ make
cc -O3 -std=c11 -I.  -c -o decode_ft8.o decode_ft8.c
decode_ft8.c: In function ‘hann_i’:
decode_ft8.c:38:27: error: ‘M_PI’ undeclared (first use in this function)
   38 |     float x = sinf((float)M_PI * i / N);
      |                           ^~~~
decode_ft8.c:38:27: note: each undeclared identifier is reported only once for each function it appears in
decode_ft8.c: In function ‘hamming_i’:
decode_ft8.c:47:32: error: ‘M_PI’ undeclared (first use in this function)
   47 |     float x1 = cosf(2 * (float)M_PI * i / N);
      |                                ^~~~
decode_ft8.c: In function ‘blackman_i’:
decode_ft8.c:58:32: error: ‘M_PI’ undeclared (first use in this function)
   58 |     float x1 = cosf(2 * (float)M_PI * i / N);
      |                                ^~~~
make: *** [<builtin>: decode_ft8.o] Error 1
```

This PR fixes these compilation errors.