### PR TITLE
Misc. fixes required on Ubuntu 21.04 (Linux)

### DIFF
--- a/ft8/unpack.c
+++ b/ft8/unpack.c
@@ -1,3 +1,6 @@
+#ifdef __linux__
+  #define _GNU_SOURCE
+#endif
 #include "unpack.h"
 #include "text.h"
 
@@ -391,7 +394,7 @@ int unpack77(const uint8_t *a77, char *message)
 {
     char call_to[14];
     char call_de[14];
-    char extra[7];
+    char extra[19];
 
     int rc = unpack77_fields(a77, call_to, call_de, extra);
     if (rc < 0)


### PR DESCRIPTION
Without these changes, I run into a bunch of problems:

```
$ make
...
In function ‘unpack_telemetry’,
    inlined from ‘unpack77_fields’ at ft8/unpack.c:365:20,
    inlined from ‘unpack77’ at ft8/unpack.c:397:14:
ft8/unpack.c:261:19: warning: writing 1 byte into a region of size 0 [-Wstringop-overflow=]
  261 |     telemetry[18] = '\0';
      |     ~~~~~~~~~~~~~~^~~~~~
ft8/unpack.c: In function ‘unpack77’:
ft8/unpack.c:395:10: note: at offset 18 into destination object ‘extra’ of size 7
  395 |     char extra[7];


  ft8/unpack.c: In function ‘unpack_type1’:
ft8/unpack.c:157:19: warning: implicit declaration of function ‘stpcpy’; did you mean ‘stpncpy’? [-Wimplicit-function-declaration]
  157 |             dst = stpcpy(dst, "R ");
      |                   ^~~~~~
      |                   stpncpy
ft8/unpack.c:157:17: warning: assignment to ‘char *’ from ‘int’ makes pointer from integer without a cast [-Wint-conversion]
  157 |             dst = stpcpy(dst, "R ");
```

```
$ ./decode_ft8 tests/websdr_test10.wav
make: Nothing to be done for 'all'.
Sample rate 12000 Hz, 92 blocks, 960 bins
Block size = 1920
Subblock size = 960
N_FFT = 3840
FFT work area = 38688
Max magnitude: -24.1 dB
zsh: segmentation fault  ./decode_ft8 tests/websdr_test10.wav
```

The `stpcpy` doesn't work well at all and returns a trunctaed pointer (int instead of char *) leading to this crash (segmentation fault) on 64-bit boxes.

After this PR,

```
$ make; ./decode_ft8 tests/websdr_test10.wav                         
make: Nothing to be done for 'all'.
Sample rate 12000 Hz, 92 blocks, 960 bins
Block size = 1920
Subblock size = 960
N_FFT = 3840
FFT work area = 38688
Max magnitude: -24.1 dB
000000  31 +0.64 2106 ~  K8JDC LZ3CQ -25
000000  27 +0.56 1431 ~  CQ F4DFQ JN05
000000  26 +0.56  534 ~  NU2Q OE4RWD R-02
000000  26 +0.48 1081 ~  W1OP WA1TGN FN42
000000  25 +0.56 1166 ~  OE5WRO SV2BRT KN10
000000  23 -0.40 2053 ~  CQ R7EL LN04
000000  23 +0.56 1738 ~  CQ PY5EJ GG54
000000  21 +0.48 2300 ~  YO3IAI WB2REM -18
000000  20 +1.44  725 ~  IW9CTR PY5HT R-15
000000  19 +0.64  988 ~  LU3DW EA8BEV IL17
000000  19 +0.64 2578 ~  CT7AIX WG5D EM62
000000  18 +1.44 2434 ~  DK7ZT NU1T -07
Decoded 12 messages
```

Things seem to be better.

```
int unpack_telemetry(const uint8_t *a71, char *telemetry)
{
    uint8_t b71[9];

    // Shift bits in a71 right by 1 bit
    uint8_t carry = 0;
    for (int i = 0; i < 9; ++i)
    {
        b71[i] = (carry << 7) | (a71[i] >> 1);
        carry = (a71[i] & 0x01);
    }

    // Convert b71 to hexadecimal string
    for (int i = 0; i < 9; ++i)
    {
        uint8_t nibble1 = (b71[i] >> 4);
        uint8_t nibble2 = (b71[i] & 0x0F);
        char c1 = (nibble1 > 9) ? (nibble1 - 10 + 'A') : nibble1 + '0';
        char c2 = (nibble2 > 9) ? (nibble2 - 10 + 'A') : nibble2 + '0';
        telemetry[i * 2] = c1;
        telemetry[i * 2 + 1] = c2;
    }

    telemetry[18] = '\0'; // NOTE NOTE NOTE
    return 0;
}
```

Since we do `telemetry[18] = '\0'` in the code, the `telemetry` buffer has to be at least 19 bytes.