### PR TITLE
Allow compilation on Android as ISO C++ code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ run_tests: test
 gen_ft8: gen_ft8.o ft8/constants.o ft8/text.o ft8/pack.o ft8/encode.o ft8/crc.o common/wave.o
 	$(CXX) $(LDFLAGS) -o $@ $^
 
-test:  test.o ft8/pack.o ft8/encode.o ft8/crc.o ft8/text.o ft8/constants.o fft/kiss_fftr.o fft/kiss_fft.o 
+test:  test.o ft8/pack.o ft8/encode.o ft8/crc.o ft8/text.o ft8/constants.o fft/kiss_fftr.o fft/kiss_fft.o
 	$(CXX) $(LDFLAGS) -o $@ $^
 
 decode_ft8: decode_ft8.o fft/kiss_fftr.o fft/kiss_fft.o ft8/decode.o ft8/encode.o ft8/crc.o ft8/ldpc.o ft8/unpack.o ft8/text.o ft8/constants.o common/wave.o
@@ -23,5 +23,5 @@ decode_ft8: decode_ft8.o fft/kiss_fftr.o fft/kiss_fft.o ft8/decode.o ft8/encode.
 clean:
 	rm -f *.o ft8/*.o common/*.o fft/*.o $(TARGETS)
 install:
-	$(AR) rc libft8.a ft8/constants.o ft8/encode.o ft8/pack.o ft8/text.o common/wave.o 
+	$(AR) rc libft8.a ft8/constants.o ft8/encode.o ft8/pack.o ft8/text.o common/wave.o
 	install libft8.a /usr/lib/libft8.a

--- a/decode_ft8.c
+++ b/decode_ft8.c
@@ -69,8 +69,8 @@ void waterfall_init(waterfall_t* me, int max_blocks, int num_bins, int time_osr,
     me->time_osr = time_osr;
     me->freq_osr = freq_osr;
     me->block_stride = (time_osr * freq_osr * num_bins);
-    me->mag = malloc(mag_size);
-    LOG(LOG_DEBUG, "Waterfall size = %lu\n", mag_size);
+    me->mag = (uint8_t  *)malloc(mag_size);
+    LOG(LOG_DEBUG, "Waterfall size = %zu\n", mag_size);
 }
 
 void waterfall_free(waterfall_t* me)
@@ -119,7 +119,7 @@ void monitor_init(monitor_t* me, const monitor_config_t* cfg)
     me->fft_norm = 2.0f / me->nfft;
     // const int len_window = 1.8f * me->block_size; // hand-picked and optimized
 
-    me->window = malloc(me->nfft * sizeof(me->window[0]));
+    me->window = (float *)malloc(me->nfft * sizeof(me->window[0]));
     for (int i = 0; i < me->nfft; ++i)
     {
         // window[i] = 1;
@@ -128,7 +128,7 @@ void monitor_init(monitor_t* me, const monitor_config_t* cfg)
         // me->window[i] = hamming_i(i, me->nfft);
         // me->window[i] = (i < len_window) ? hann_i(i, len_window) : 0;
     }
-    me->last_frame = malloc(me->nfft * sizeof(me->last_frame[0]));
+    me->last_frame = (float *)malloc(me->nfft * sizeof(me->last_frame[0]));
 
     size_t fft_work_size;
     kiss_fftr_alloc(me->nfft, 0, 0, &fft_work_size);
@@ -136,7 +136,7 @@ void monitor_init(monitor_t* me, const monitor_config_t* cfg)
     LOG(LOG_INFO, "Block size = %d\n", me->block_size);
     LOG(LOG_INFO, "Subblock size = %d\n", me->subblock_size);
     LOG(LOG_INFO, "N_FFT = %d\n", me->nfft);
-    LOG(LOG_DEBUG, "FFT work area = %lu\n", fft_work_size);
+    LOG(LOG_DEBUG, "FFT work area = %zu\n", fft_work_size);
 
     me->fft_work = malloc(fft_work_size);
     me->fft_cfg = kiss_fftr_alloc(me->nfft, 0, me->fft_work, &fft_work_size);
@@ -283,11 +283,11 @@ int main(int argc, char** argv)
     // Compute FFT over the whole signal and store it
     monitor_t mon;
     monitor_config_t mon_cfg = {
+        .f_min = 100,
+        .f_max = 3000,
         .sample_rate = sample_rate,
         .time_osr = kTime_osr,
         .freq_osr = kFreq_osr,
-        .f_min = 100,
-        .f_max = 3000,
         .protocol = is_ft8 ? PROTO_FT8 : PROTO_FT4
     };
     monitor_init(&mon, &mon_cfg);

--- a/ft8/unpack.c
+++ b/ft8/unpack.c
@@ -1,6 +1,9 @@
 #ifdef __linux__
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
 #endif
+#endif
+
 #include "unpack.h"
 #include "text.h"
 


### PR DESCRIPTION
This PR contains a bunch of trivial fixes:

- The `size_t` variables require `%zu` specifier.

- The return of malloc calls are properly type casted.

- Small whitespace fixes in `Makefile`.

- This PR also fixes the following warnings:

   ```
   warning: ISO C++ requires field designators to be specified in declaration order; field 'freq_osr' will be initialized after field 'f_min' [-Wreorder-init-list]
   ```
- The `_GNU_SOURCE` definition is now guarded properly. This fixes a compilation warning on Android.

Thanks! :+1: 