### PR TITLE
Fix a memory leak in decode_ft8.c

### DIFF
--- a/decode_ft8.c
+++ b/decode_ft8.c
@@ -383,5 +383,7 @@ int main(int argc, char** argv)
     }
     LOG(LOG_INFO, "Decoded %d messages\n", num_decoded);
 
+    monitor_free(&mon);
+
     return 0;
 }


### PR DESCRIPTION
This fix is useful when ft8_lib is used as a library.

Fixes: https://github.com/kgoba/ft8_lib/issues/19.