### PR TITLE
Support for packing telemetry frames

### DIFF
--- a/ft8/pack.c
+++ b/ft8/pack.c
@@ -358,7 +358,7 @@ int pack77(const char* msg, uint8_t* c77)
         if(hex_ok >= 0) {
             return 0;
         } else {
-            return 1;
+            return -1;
         }
     }
 


### PR DESCRIPTION
The following works for me. I'll add some tests later on.
Also, I've tested decoding generated telemetry packets this way via WSJTX.
Full 18 hex characters to trigger packing as telemetry - but it's an example anyway.