### PR TITLE
Adding telemetry encoding support; webft8.github.io

### DIFF
--- a/common/monitor.c
+++ b/common/monitor.c
@@ -1,7 +1,7 @@
 #include "monitor.h"
 #include <common/common.h>
 
-#define LOG_LEVEL LOG_INFO
+#define LOG_LEVEL LOG_WARN
 #include <ft8/debug.h>
 
 #include <stdlib.h>

--- a/ft8/message.h
+++ b/ft8/message.h
@@ -106,8 +106,9 @@ ftx_message_rc_t ftx_message_encode_std(ftx_message_t* msg, ftx_callsign_hash_in
 ftx_message_rc_t ftx_message_encode_nonstd(ftx_message_t* msg, ftx_callsign_hash_interface_t* hash_if, const char* call_to, const char* call_de, const char* extra);
 
 void ftx_message_encode_free(const char* text);
-void ftx_message_encode_telemetry_hex(const char* telemetry_hex);
-void ftx_message_encode_telemetry(const uint8_t* telemetry);
+
+ftx_message_rc_t ftx_message_encode_telemetry_hex(ftx_message_t* msg, const char* telemetry_hex);
+ftx_message_rc_t ftx_message_encode_telemetry(ftx_message_t* msg, const uint8_t* telemetry);
 
 ftx_message_rc_t ftx_message_decode(const ftx_message_t* msg, ftx_callsign_hash_interface_t* hash_if, char* message);
 ftx_message_rc_t ftx_message_decode_std(const ftx_message_t* msg, ftx_callsign_hash_interface_t* hash_if, char* call_to, char* call_de, char* extra);


### PR DESCRIPTION
Finally had some time during the weekend to port it to the correct branch.

Also, I'd like to share with you project using your library: https://github.com/webft8/webft8 - FT8 decoder running in web browser. Your library works compiled to web assembly, live demo: https://webft8.github.io