### PR TITLE
fix: possible integer overflow

### DIFF
--- a/common/wave.c
+++ b/common/wave.c
@@ -25,7 +25,7 @@ void save_wav(const float* signal, int num_samples, int sample_rate, const char*
     uint32_t chunkSize = 4 + (8 + subChunk1Size) + (8 + subChunk2Size);
     char format[4] = { 'W', 'A', 'V', 'E' };
 
-    int16_t* raw_data = (int16_t*)malloc(num_samples * blockAlign);
+    int16_t* raw_data = (int16_t*)malloc((int16_t) num_samples * blockAlign);
     for (int i = 0; i < num_samples; i++)
     {
         float x = signal[i];
@@ -112,7 +112,7 @@ int load_wav(float* signal, int* num_samples, int* sample_rate, const char* path
     *num_samples = subChunk2Size / blockAlign;
     *sample_rate = sampleRate;
 
-    int16_t* raw_data = (int16_t*)malloc(*num_samples * blockAlign);
+    int16_t* raw_data = (int16_t*)calloc(*num_samples * blockAlign);
 
     fread((void*)raw_data, blockAlign, *num_samples, f);
     for (int i = 0; i < *num_samples; i++)

--- a/decode_ft8.c
+++ b/decode_ft8.c
@@ -119,7 +119,7 @@ void monitor_init(monitor_t* me, const monitor_config_t* cfg)
     me->fft_norm = 2.0f / me->nfft;
     // const int len_window = 1.8f * me->block_size; // hand-picked and optimized
 
-    me->window = (float *)malloc(me->nfft * sizeof(me->window[0]));
+    me->window = (float *)calloc(me->nfft * sizeof(me->window[0]));
     for (int i = 0; i < me->nfft; ++i)
     {
         // window[i] = 1;
@@ -128,7 +128,7 @@ void monitor_init(monitor_t* me, const monitor_config_t* cfg)
         // me->window[i] = hamming_i(i, me->nfft);
         // me->window[i] = (i < len_window) ? hann_i(i, len_window) : 0;
     }
-    me->last_frame = (float *)malloc(me->nfft * sizeof(me->last_frame[0]));
+    me->last_frame = (float *)calloc(me->nfft * sizeof(me->last_frame[0]));
 
     size_t fft_work_size;
     kiss_fftr_alloc(me->nfft, 0, 0, &fft_work_size);


### PR DESCRIPTION
If user input is large enough, the multiplication to calculate malloc() size could overflow.