### PR TITLE
Restore 'free text' encoding support

### DIFF
--- a/demo/decode_ft8.c
+++ b/demo/decode_ft8.c
@@ -1,3 +1,5 @@
+#define _POSIX_C_SOURCE 199309L
+
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>

--- a/demo/gen_ft8.c
+++ b/demo/gen_ft8.c
@@ -111,6 +111,8 @@ void usage()
     printf("(Note that you might have to enclose your message in quote marks if it contains spaces)\n");
 }
 
+void packtext77(const char* text, uint8_t* b77);
+
 int main(int argc, char** argv)
 {
     // Expect two command-line arguments
@@ -134,9 +136,14 @@ int main(int argc, char** argv)
     ftx_message_rc_t rc = ftx_message_encode(&msg, NULL, message);
     if (rc != FTX_MESSAGE_RC_OK)
     {
-        printf("Cannot parse message!\n");
-        printf("RC = %d\n", (int)rc);
-        return -2;
+        // Try 'free text' encoding
+        if (strlen(message) <= 13)
+            packtext77(message, (uint8_t *)&msg.payload);
+        else {
+            printf("Cannot parse message!\n");
+            printf("RC = %d\n", (int)rc);
+            return -2;
+       }
     }
 
     printf("Packed data: ");


### PR DESCRIPTION
Before this PR:

```
$ ./gen_ft8 "U09TUNQUC9ZH12" eifel.wav 850
Cannot parse message!
RC = 1
```

After this PR:

```
$ ./gen_ft8 "U09TUNQUC9ZH" eifel.wav 850
Packed data: 65 5d 15 26 47 bc 89 30 08 00 
FSK tones: 3140652213645361155247553320010005223140652043464134672561142261533033043140652
```

WSJT-X decodes eifel.wav just fine.

![Screenshot_2023-12-11_08-58-06](https://github.com/kgoba/ft8_lib/assets/79528/359be03f-3d47-4fbb-8a03-70b1c1062e96)

The `U09TUNQUC9ZH` happens to be the Geohash for Eifel Tower's coordinates.

![Screenshot_2023-12-11_08-58-51](https://github.com/kgoba/ft8_lib/assets/79528/f36f99c4-eb20-406c-b95e-ca22be8905bf)

This Geohash feature can be used to be build a "New APRS" system for HF.