### PR TITLE
fix compile error and warnings on ubuntu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@ gen_ft8
 decode_ft8
 test_ft8
 libft8.a
+*.wav
+*.o
 wsjtx2/
 .build/
 .DS_Store

--- a/common/wave.c
+++ b/common/wave.c
@@ -89,27 +89,52 @@ int load_wav(float* signal, int* num_samples, int* sample_rate, const char* path
         return -1;
 
     // NOTE: works only on little-endian architecture
-    fread((void*)chunkID, sizeof(chunkID), 1, f);
-    fread((void*)&chunkSize, sizeof(chunkSize), 1, f);
-    fread((void*)format, sizeof(format), 1, f);
+    size_t readResult = fread((void*)chunkID, sizeof(chunkID), 1, f);
+    if (readResult != 1)
+        return -1;
+    readResult = fread((void*)&chunkSize, sizeof(chunkSize), 1, f);
+    if (readResult != 1)
+        return -1;
+    readResult = fread((void*)format, sizeof(format), 1, f);
+    if (readResult != 1)
+        return -1;
 
-    fread((void*)subChunk1ID, sizeof(subChunk1ID), 1, f);
-    fread((void*)&subChunk1Size, sizeof(subChunk1Size), 1, f);
+    readResult = fread((void*)subChunk1ID, sizeof(subChunk1ID), 1, f);
+    if (readResult != 1)
+        return -2;
+    readResult = fread((void*)&subChunk1Size, sizeof(subChunk1Size), 1, f);
+    if (readResult != 1)
+        return -2;
     if (subChunk1Size != 16)
         return -2;
 
-    fread((void*)&audioFormat, sizeof(audioFormat), 1, f);
-    fread((void*)&numChannels, sizeof(numChannels), 1, f);
-    fread((void*)&sampleRate, sizeof(sampleRate), 1, f);
-    fread((void*)&byteRate, sizeof(byteRate), 1, f);
-    fread((void*)&blockAlign, sizeof(blockAlign), 1, f);
-    fread((void*)&bitsPerSample, sizeof(bitsPerSample), 1, f);
-
+    readResult = fread((void*)&audioFormat, sizeof(audioFormat), 1, f);
+    if (readResult != 1)
+        return -3;
+    readResult = fread((void*)&numChannels, sizeof(numChannels), 1, f);
+    if (readResult != 1)
+        return -3;
+    readResult = fread((void*)&sampleRate, sizeof(sampleRate), 1, f);
+    if (readResult != 1)
+        return -3;
+    readResult = fread((void*)&byteRate, sizeof(byteRate), 1, f);
+    if (readResult != 1)
+        return -3;
+    readResult = fread((void*)&blockAlign, sizeof(blockAlign), 1, f);
+    if (readResult != 1)
+        return -3;
+    readResult = fread((void*)&bitsPerSample, sizeof(bitsPerSample), 1, f);
+    if (readResult != 1)
+        return -3;
     if (audioFormat != 1 || numChannels != 1 || bitsPerSample != 16)
         return -3;
 
-    fread((void*)subChunk2ID, sizeof(subChunk2ID), 1, f);
-    fread((void*)&subChunk2Size, sizeof(subChunk2Size), 1, f);
+    readResult = fread((void*)subChunk2ID, sizeof(subChunk2ID), 1, f);
+    if (readResult != 1)
+        return -4;
+    readResult = fread((void*)&subChunk2Size, sizeof(subChunk2Size), 1, f);
+    if (readResult != 1)
+        return -4;
 
     if (subChunk2Size / blockAlign > *num_samples)
         return -4;
@@ -119,7 +144,9 @@ int load_wav(float* signal, int* num_samples, int* sample_rate, const char* path
 
     int16_t* raw_data = (int16_t*)malloc(*num_samples * blockAlign);
 
-    fread((void*)raw_data, blockAlign, *num_samples, f);
+    readResult = fread((void*)raw_data, blockAlign, *num_samples, f);
+    if (readResult != *num_samples)
+        return -5;
     for (int i = 0; i < *num_samples; i++)
     {
         signal[i] = raw_data[i] / 32768.0f;

--- a/demo/decode_ft8.c
+++ b/demo/decode_ft8.c
@@ -1,3 +1,4 @@
+#define _POSIX_C_SOURCE 199309L
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>

--- a/ft8/message.c
+++ b/ft8/message.c
@@ -1,3 +1,4 @@
+#include "sysdefs.h"
 #include "message.h"
 #include "text.h"
 #include <stdlib.h>
@@ -420,7 +421,7 @@ ftx_message_rc_t ftx_message_decode_nonstd(const ftx_message_t* msg, ftx_callsig
 
     // Extract i3 (bits 74..76)
     uint8_t i3 = (msg->payload[9] >> 3) & 0x07u;
-    LOG(LOG_DEBUG, "decode_nonstd() n12=%04x n58=%08llx iflip=%d nrpt=%d icq=%d i3=%d\n", n12, n58, iflip, nrpt, icq, i3);
+    LOG(LOG_DEBUG, "decode_nonstd() n12=%04x n58=%08lx iflip=%d nrpt=%d icq=%d i3=%d\n", n12, n58, iflip, nrpt, icq, i3);
 
     // Decode one of the calls from 58 bit encoded string
     char call_decoded[14];
@@ -865,7 +866,7 @@ static bool pack58(const ftx_callsign_hash_interface_t* hash_if, const char* cal
         return false;
 
     *n58 = result;
-    LOG(LOG_DEBUG, "pack58('%s')=%016llx\n", callsign, *n58);
+    LOG(LOG_DEBUG, "pack58('%s')=%016lx\n", callsign, *n58);
     return true;
 }
 
@@ -885,7 +886,7 @@ static bool unpack58(uint64_t n58, const ftx_callsign_hash_interface_t* hash_if,
     // The decoded string will be right-aligned, so trim all whitespace (also from back just in case)
     trim_copy(callsign, c11);
 
-    LOG(LOG_DEBUG, "unpack58(%016llx)=%s\n", n58_backup, callsign);
+    LOG(LOG_DEBUG, "unpack58(%016lx)=%s\n", n58_backup, callsign);
 
     // Save the decoded call in a hash table for later
     if (strlen(callsign) >= 3)

--- a/ft8/sysdefs.h
+++ b/ft8/sysdefs.h
@@ -1,0 +1,8 @@
+#ifndef _INCLUDE_SYSDEFS_H_
+#define _INCLUDE_SYSDEFS_H_
+
+#ifndef __HAVE_ARCH_STPCPY
+char *stpcpy(char *__restrict__ dest, const char *__restrict__ src);
+#endif
+
+#endif

--- a/test/test.c
+++ b/test/test.c
@@ -7,6 +7,7 @@
 #include "ft8/text.h"
 #include "ft8/encode.h"
 #include "ft8/constants.h"
+#include "ft8/sysdefs.h"
 
 #include "fft/kiss_fftr.h"
 #include "common/common.h"


### PR DESCRIPTION
Fixes this error (compiled on ubuntu linux 22.04):

```
demo/decode_ft8.c:347:31: error: ‘CLOCK_REALTIME’ undeclared (first use in this function)
  347 |                 clock_gettime(CLOCK_REALTIME, &spec);
```

Also fixes these warnings:

```
warning: ignoring return value of ‘fread’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
  122 |     fread((void*)raw_data, blockAlign, *num_samples, f);

warning: implicit declaration of function ‘stpcpy’; did you mean ‘strcpy’? [-Wimplicit-function-declaration]
  953 |             dst = stpcpy(dst, "R ");

warning: format ‘%llx’ expects argument of type ‘long long unsigned int’, but argument 4 has type ‘uint64_t’ {aka ‘long unsigned int’} [-Wformat=]
  423 |     LOG(LOG_DEBUG, "decode_nonstd() n12=%04x n58=%08llx iflip=%d nrpt=%d icq=%d i3=%d\n", n12, n58, iflip, nrpt, icq, i3);


```

Also added a bunch of files to the gitignore list.