### PR TITLE
Make win32 (mingw64) compatible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ wsjtx2/
 .DS_Store
 .vscode/
 __pycache__/
+*.exe

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 BUILD_DIR = .build
 
+USE_ASAN = 1  # Set to 1 to enable AddressSanitizer
+
 FT8_SRC  = $(wildcard ft8/*.c)
 FT8_OBJ  = $(patsubst %.c,$(BUILD_DIR)/%.o,$(FT8_SRC))
 
@@ -11,9 +13,14 @@ FFT_OBJ  = $(patsubst %.c,$(BUILD_DIR)/%.o,$(FFT_SRC))
 
 TARGETS  = gen_ft8 decode_ft8 test_ft8
 
-CFLAGS   = -fsanitize=address -O3 -ggdb3
+CFLAGS   = -D_GNU_SOURCE -O3 -ggdb3
 CPPFLAGS = -std=c11 -I.
-LDFLAGS  = -fsanitize=address -lm
+LDFLAGS  = -lm
+
+ifeq ($(USE_ASAN), 1)
+CFLAGS  += -fsanitize=address
+LDFLAGS += -fsanitize=address
+endif
 
 # Optionally, use Portaudio for live audio input
 ifdef PORTAUDIO_PREFIX

--- a/demo/decode_ft8.c
+++ b/demo/decode_ft8.c
@@ -17,6 +17,10 @@
 #define LOG_LEVEL LOG_INFO
 #include <ft8/debug.h>
 
+#ifdef _WIN32
+#define gmtime_r(timep, result) gmtime_s(result, timep)
+#endif
+
 const int kMin_score = 10; // Minimum sync score threshold for candidates
 const int kMax_candidates = 140;
 const int kLDPC_iterations = 25;

--- a/ft8/message.c
+++ b/ft8/message.c
@@ -10,6 +10,16 @@
 #define NTOKENS  ((uint32_t)2063592ul)
 #define MAXGRID4 ((uint16_t)32400ul)
 
+#ifndef HAVE_STPCPY
+#define HAVE_STPCPY
+
+static char *stpcpy(char *dest, const char *src) {
+    strcpy(dest, src);
+    return dest + strlen(src);
+}
+
+#endif
+
 ////////////////////////////////////////////////////// Static function prototypes //////////////////////////////////////////////////////////////
 
 static bool trim_brackets(char* result, const char* original, int length);

--- a/test/test.c
+++ b/test/test.c
@@ -15,6 +15,16 @@
 #define LOG_LEVEL LOG_INFO
 #include "ft8/debug.h"
 
+#ifndef HAVE_STPCPY
+#define HAVE_STPCPY
+
+static char *stpcpy(char *dest, const char *src) {
+    strcpy(dest, src);
+    return dest + strlen(src);
+}
+
+#endif
+
 // void convert_8bit_to_6bit(uint8_t* dst, const uint8_t* src, int nBits)
 // {
 //     // Zero-fill the destination array as we will only be setting bits later


### PR DESCRIPTION
I've tweaked some files so I could compile `gen_ft8.exe` under MSYS2 on Windows. I can run `gen_ft8.exe` in Windows, and with it I have successfully created a .wav which could be opened and decoded by WSJT-X on Windows 10.

![image](https://github.com/kgoba/ft8_lib/assets/800133/b0d32e60-a0da-4b40-8089-4addb4cfcc4c)

`test_ft8.exe` gives "Test OK" 3808 times. I have not yet tested any other binary outputs, but it all compiled successfully.

Made this pull request in case you want to take the changes on. I understand if this project has no interest in maintaining Windows compatibility.

Main changes:

* Added Windows/mingw64 fallbacks for `stpcpy` and `gmtime_r`.

* `USE_ASAN = 1`  has been added to the Makefile which allows you to turn on/off the flag `-fsanitize=address` more easily. This is because I needed to turn it off for mingw64 to get it to compile. But I've just left it on (i.e. unchanged), requiring manual editing to `= 0` for a Windows build

My goal is to make a C# wrapper for ft8_lib. I'm no expert, just working out what I'm doing as I go.

Hope this is something useful and I haven't gone down the wrong path.