### PR TITLE
non-standard callsigns; special CQ; field type annotation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,13 +11,13 @@ FFT_OBJ  = $(patsubst %.c,$(BUILD_DIR)/%.o,$(FFT_SRC))
 
 TARGETS  = gen_ft8 decode_ft8 test_ft8
 
-CFLAGS   = -fsanitize=address -O3 -ggdb3
-CPPFLAGS = -std=c11 -I.
+CFLAGS   = -fsanitize=address -O3 -ggdb3 -DHAVE_STPCPY -I.
 LDFLAGS  = -fsanitize=address -lm
 
 # Optionally, use Portaudio for live audio input
+# Portaudio is a C++ library, so then you need to set CC=clang++ or CC=g++
 ifdef PORTAUDIO_PREFIX
-CPPFLAGS += -DUSE_PORTAUDIO -I$(PORTAUDIO_PREFIX)/include
+CFLAGS   += -DUSE_PORTAUDIO -I$(PORTAUDIO_PREFIX)/include
 LDFLAGS  += -lportaudio -L$(PORTAUDIO_PREFIX)/lib
 endif
 
@@ -26,7 +26,7 @@ endif
 all: $(TARGETS)
 
 clean:
-	rm -rf $(BUILD_DIR) $(TARGETS) 
+	rm -rf $(BUILD_DIR) $(TARGETS)
 
 run_tests: test_ft8
 	@./test_ft8
@@ -46,4 +46,4 @@ test_ft8: $(BUILD_DIR)/test/test.o $(FT8_OBJ)
 
 $(BUILD_DIR)/%.o: %.c
 	@mkdir -p $(dir $@)
-	$(CC) $(CFLAGS) $(CPPFLAGS) -o $@ -c $^
+	$(CC) $(CFLAGS) -o $@ -c $^

--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,15 @@ COMMON_OBJ = $(patsubst %.c,$(BUILD_DIR)/%.o,$(COMMON_SRC))
 FFT_SRC  = $(wildcard fft/*.c)
 FFT_OBJ  = $(patsubst %.c,$(BUILD_DIR)/%.o,$(FFT_SRC))
 
-TARGETS  = gen_ft8 decode_ft8 test_ft8
+TARGETS  = libft8.a gen_ft8 decode_ft8 test_ft8
 
-CFLAGS   = -fsanitize=address -O3 -ggdb3 -DHAVE_STPCPY -I.
+ifdef FT8_DEBUG
+CFLAGS   = -fsanitize=address -ggdb3 -DHAVE_STPCPY -I. -DFTX_DEBUG_PRINT
 LDFLAGS  = -fsanitize=address -lm
+else
+CFLAGS   = -O3 -DHAVE_STPCPY -I.
+LDFLAGS  = -lm
+endif
 
 # Optionally, use Portaudio for live audio input
 # Portaudio is a C++ library, so then you need to set CC=clang++ or CC=g++
@@ -31,19 +36,23 @@ clean:
 run_tests: test_ft8
 	@./test_ft8
 
-install:
-	$(AR) rc libft8.a $(FT8_OBJ) $(COMMON_OBJ)
+install: libft8.a
 	install libft8.a /usr/lib/libft8.a
 
-gen_ft8: $(BUILD_DIR)/demo/gen_ft8.o $(FT8_OBJ) $(COMMON_OBJ) $(FFT_OBJ)
-	$(CC) $(LDFLAGS) -o $@ $^
+gen_ft8: $(BUILD_DIR)/demo/gen_ft8.o libft8.a
+	$(CC) $(CFLAGS) -o $@ .build/demo/gen_ft8.o -lft8 -L. -lm
 
-decode_ft8: $(BUILD_DIR)/demo/decode_ft8.o $(FT8_OBJ) $(COMMON_OBJ) $(FFT_OBJ)
-	$(CC) $(LDFLAGS) -o $@ $^
+decode_ft8: $(BUILD_DIR)/demo/decode_ft8.o libft8.a $(FFT_OBJ)
+	$(CC) $(CFLAGS) -o $@ $(BUILD_DIR)/demo/decode_ft8.o $(FFT_OBJ) -lft8 -L. -lm
 
-test_ft8: $(BUILD_DIR)/test/test.o $(FT8_OBJ)
-	$(CC) $(LDFLAGS) -o $@ $^
+test_ft8: $(BUILD_DIR)/test/test.o libft8.a
+	$(CC) $(CFLAGS) -o $@ .build/test/test.o -lft8 -L. -lm
 
 $(BUILD_DIR)/%.o: %.c
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) -o $@ -c $^
+
+lib: libft8.a
+
+libft8.a: $(FT8_OBJ) $(COMMON_OBJ)
+	$(AR) rc libft8.a $(FT8_OBJ) $(COMMON_OBJ)

--- a/demo/decode_ft8.c
+++ b/demo/decode_ft8.c
@@ -1,3 +1,4 @@
+#define _POSIX_C_SOURCE 199309L
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>

--- a/demo/decode_ft8.c
+++ b/demo/decode_ft8.c
@@ -213,7 +213,8 @@ void decode(const monitor_t* mon, struct tm* tm_slot_start)
             ++num_decoded;
 
             char text[FTX_MAX_MESSAGE_LENGTH];
-            ftx_message_rc_t unpack_status = ftx_message_decode(&message, &hash_if, text);
+            ftx_message_offsets_t offsets;
+            ftx_message_rc_t unpack_status = ftx_message_decode(&message, &hash_if, text, &offsets);
             if (unpack_status != FTX_MESSAGE_RC_OK)
             {
                 snprintf(text, sizeof(text), "Error [%d] while unpacking!", (int)unpack_status);

--- a/ft8/message.c
+++ b/ft8/message.c
@@ -142,15 +142,21 @@ ftx_message_rc_t ftx_message_encode(ftx_message_t* msg, ftx_callsign_hash_interf
     }
 
     ftx_message_rc_t rc;
-    rc = ftx_message_encode_std(msg, hash_if, call_to, call_de, extra);
-    if (rc == FTX_MESSAGE_RC_OK)
-        return rc;
-    rc = ftx_message_encode_nonstd(msg, hash_if, call_to, call_de, extra);
-    if (rc == FTX_MESSAGE_RC_OK)
-        return rc;
+    if (!parse_position[0]) {
+        // up to 3 tokens with no leftovers
+        rc = ftx_message_encode_std(msg, hash_if, call_to, call_de, extra);
+        if (rc == FTX_MESSAGE_RC_OK)
+            return rc;
+        LOG(LOG_DEBUG, "   ftx_message_encode_std failed: %d\n", rc);
+        rc = ftx_message_encode_nonstd(msg, hash_if, call_to, call_de, extra);
+        if (rc == FTX_MESSAGE_RC_OK)
+            return rc;
+        LOG(LOG_DEBUG, "   ftx_message_encode_nonstd failed: %d\n", rc);
+    }
     rc = ftx_message_encode_free(msg, message_text);
     if (rc == FTX_MESSAGE_RC_OK)
         return rc;
+    LOG(LOG_DEBUG, "   ftx_message_encode_free failed: %d\n", rc);
 
     return rc;
 }

--- a/ft8/message.c
+++ b/ft8/message.c
@@ -124,6 +124,8 @@ ftx_message_rc_t ftx_message_encode(ftx_message_t* msg, ftx_callsign_hash_interf
     parse_position = copy_token(call_de, 12, parse_position);
     parse_position = copy_token(extra, 20, parse_position);
 
+    LOG(LOG_DEBUG, "ftx_message_encode: parsed '%s' '%s' %d '%s'; remaining chars '%s'\n", call_to, call_de, is_call_de, extra, parse_position);
+
     if (call_to[11] != '\0')
     {
         // token too long
@@ -335,9 +337,12 @@ ftx_message_rc_t ftx_message_encode_free(ftx_message_t* msg, const char* text)
             rem = rem >> 8;
         }
     }
-    return ftx_message_encode_telemetry(msg, b71);
+    ftx_message_rc_t ret = ftx_message_encode_telemetry(msg, b71);
+    msg->payload[9] = 0; // i3.n3 = 0.0; etc.
+    return ret;
 }
 
+// TODO set byte 9? or must the caller do it?
 ftx_message_rc_t ftx_message_encode_telemetry(ftx_message_t* msg, const uint8_t* telemetry)
 {
     // Shift bits in telemetry left by 1 bit to right-align the data

--- a/ft8/message.c
+++ b/ft8/message.c
@@ -24,8 +24,6 @@ static void add_brackets(char* result, const char* original, int length);
 static bool save_callsign(const ftx_callsign_hash_interface_t* hash_if, const char* callsign, uint32_t* n22_out, uint16_t* n12_out, uint16_t* n10_out);
 static bool lookup_callsign(const ftx_callsign_hash_interface_t* hash_if, ftx_callsign_hash_type_t hash_type, uint32_t hash, char* callsign);
 
-static int32_t pack_basecall(const char* callsign, int length);
-
 /// Pack a special token, a 22-bit hash code, or a valid base call into a 29-bit integer.
 static int32_t pack28(const char* callsign, const ftx_callsign_hash_interface_t* hash_if, uint8_t* ip);
 
@@ -689,7 +687,7 @@ static bool lookup_callsign(const ftx_callsign_hash_interface_t* hash_if, ftx_ca
     return found;
 }
 
-static int32_t pack_basecall(const char* callsign, int length)
+int32_t pack_basecall(const char* callsign, int length)
 {
     if (length > 2)
     {

--- a/ft8/message.c
+++ b/ft8/message.c
@@ -518,11 +518,11 @@ void ftx_message_decode_telemetry(const ftx_message_t* msg, uint8_t* telemetry)
 void ftx_message_print(ftx_message_t* msg)
 {
     printf("[");
-    for (int i = 0; i < PAYLOAD_LENGTH_BYTES; ++i)
+    for (int i = 0; i < FTX_PAYLOAD_LENGTH_BYTES; ++i)
     {
         if (i > 0)
             printf(" ");
-        printf("%02x", msg->payload[i]));
+        printf("%02x", msg->payload[i]);
     }
     printf("]");
 }

--- a/ft8/message.h
+++ b/ft8/message.h
@@ -105,9 +105,8 @@ ftx_message_rc_t ftx_message_encode_std(ftx_message_t* msg, ftx_callsign_hash_in
 /// Pack Type 4 (One nonstandard call and one hashed call) message
 ftx_message_rc_t ftx_message_encode_nonstd(ftx_message_t* msg, ftx_callsign_hash_interface_t* hash_if, const char* call_to, const char* call_de, const char* extra);
 
-void ftx_message_encode_free(const char* text);
-void ftx_message_encode_telemetry_hex(const char* telemetry_hex);
-void ftx_message_encode_telemetry(const uint8_t* telemetry);
+ftx_message_rc_t ftx_message_encode_free(ftx_message_t* msg, const char* text);
+ftx_message_rc_t ftx_message_encode_telemetry(ftx_message_t* msg, const uint8_t* telemetry);
 
 ftx_message_rc_t ftx_message_decode(const ftx_message_t* msg, ftx_callsign_hash_interface_t* hash_if, char* message);
 ftx_message_rc_t ftx_message_decode_std(const ftx_message_t* msg, ftx_callsign_hash_interface_t* hash_if, char* call_to, char* call_de, char* extra);

--- a/ft8/message.h
+++ b/ft8/message.h
@@ -116,6 +116,12 @@ ftx_message_type_t ftx_message_get_type(const ftx_message_t* msg);
 
 // bool ftx_message_check_recipient(const ftx_message_t* msg, const char* callsign);
 
+/// Pack (encode) a callsign in the standard way, and return the numeric representation.
+/// Returns -1 if \a callsign cannot be encoded in the standard way.
+/// This function can be used to decide whether to call ftx_message_encode_std() or ftx_message_decode_nonstd().
+/// Alternatively, ftx_message_encode_std() itself fails when one of the callsigns cannot be packed this way.
+int32_t pack_basecall(const char* callsign, int length);
+
 /// Pack (encode) a text message, guessing which message type to use and falling back on failure:
 /// if there are 3 or fewer tokens, try ftx_message_encode_std first,
 /// then ftx_message_encode_nonstd if that fails because of a non-standard callsign;

--- a/ft8/message.h
+++ b/ft8/message.h
@@ -11,6 +11,7 @@ extern "C"
 
 #define FTX_PAYLOAD_LENGTH_BYTES 10 ///< number of bytes to hold 77 bits of FTx payload data
 #define FTX_MAX_MESSAGE_LENGTH   35 ///< max message length = callsign[13] + space + callsign[13] + space + report[6] + terminator
+#define FTX_MAX_MESSAGE_FIELDS   3  // may need to get longer for multi-part messages (DXpedition, contest etc.)
 
 /// Structure that holds the decoded message
 typedef struct
@@ -78,6 +79,28 @@ typedef enum
     FTX_MESSAGE_RC_ERROR_TYPE
 } ftx_message_rc_t;
 
+typedef enum
+{
+    FTX_FIELD_UNKNOWN,
+    FTX_FIELD_NONE,
+    FTX_FIELD_TOKEN,          // RRR, RR73, 73, DE, QRZ, CQ, ...
+    FTX_FIELD_TOKEN_WITH_ARG, // CQ nnn, CQ abcd
+    FTX_FIELD_CALL,
+    FTX_FIELD_GRID,
+    FTX_FIELD_RST
+} ftx_field_t;
+
+typedef struct
+{
+    // parallel arrays:
+    // e.g. "CQ POTA W9XYZ AB12" generates
+    // types { FTX_FIELD_TOKEN_WITH_ARG, FTX_FIELD_CALL, FTX_FIELD_CALL_GRID" }
+    // offsets { 0, 8, 14 }
+    // Both arrays end where offsets[i] < 0
+    ftx_field_t types[FTX_MAX_MESSAGE_FIELDS];
+    int16_t offsets[FTX_MAX_MESSAGE_FIELDS];
+} ftx_message_offsets_t;
+
 // Callsign types and sizes:
 // * Std. call (basecall) - 1-2 letter/digit prefix (at least one letter), 1 digit area code, 1-3 letter suffix,
 //                          total 3-6 chars (exception: 7 character calls with prefixes 3DA0- and 3XA..3XZ-)
@@ -108,9 +131,9 @@ ftx_message_rc_t ftx_message_encode_nonstd(ftx_message_t* msg, ftx_callsign_hash
 ftx_message_rc_t ftx_message_encode_free(ftx_message_t* msg, const char* text);
 ftx_message_rc_t ftx_message_encode_telemetry(ftx_message_t* msg, const uint8_t* telemetry);
 
-ftx_message_rc_t ftx_message_decode(const ftx_message_t* msg, ftx_callsign_hash_interface_t* hash_if, char* message);
-ftx_message_rc_t ftx_message_decode_std(const ftx_message_t* msg, ftx_callsign_hash_interface_t* hash_if, char* call_to, char* call_de, char* extra);
-ftx_message_rc_t ftx_message_decode_nonstd(const ftx_message_t* msg, ftx_callsign_hash_interface_t* hash_if, char* call_to, char* call_de, char* extra);
+ftx_message_rc_t ftx_message_decode(const ftx_message_t* msg, ftx_callsign_hash_interface_t* hash_if, char* message, ftx_message_offsets_t* offsets);
+ftx_message_rc_t ftx_message_decode_std(const ftx_message_t* msg, ftx_callsign_hash_interface_t* hash_if, char* call_to, char* call_de, char* extra, ftx_field_t field_types[FTX_MAX_MESSAGE_FIELDS]);
+ftx_message_rc_t ftx_message_decode_nonstd(const ftx_message_t* msg, ftx_callsign_hash_interface_t* hash_if, char* call_to, char* call_de, char* extra, ftx_field_t field_types[FTX_MAX_MESSAGE_FIELDS]);
 void ftx_message_decode_free(const ftx_message_t* msg, char* text);
 void ftx_message_decode_telemetry_hex(const ftx_message_t* msg, char* telemetry_hex);
 void ftx_message_decode_telemetry(const ftx_message_t* msg, uint8_t* telemetry);

--- a/ft8/message.h
+++ b/ft8/message.h
@@ -116,7 +116,11 @@ ftx_message_type_t ftx_message_get_type(const ftx_message_t* msg);
 
 // bool ftx_message_check_recipient(const ftx_message_t* msg, const char* callsign);
 
-/// Pack (encode) a text message
+/// Pack (encode) a text message, guessing which message type to use and falling back on failure:
+/// if there are 3 or fewer tokens, try ftx_message_encode_std first,
+/// then ftx_message_encode_nonstd if that fails because of a non-standard callsign;
+/// otherwise fall back to ftx_message_encode_free.
+/// If you already know which type to use, you can call one of those functions directly.
 ftx_message_rc_t ftx_message_encode(ftx_message_t* msg, ftx_callsign_hash_interface_t* hash_if, const char* message_text);
 
 /// Pack Type 1 (Standard 77-bit message) or Type 2 (ditto, with a "/P" call) message
@@ -128,6 +132,7 @@ ftx_message_rc_t ftx_message_encode_std(ftx_message_t* msg, ftx_callsign_hash_in
 /// Pack Type 4 (One nonstandard call and one hashed call) message
 ftx_message_rc_t ftx_message_encode_nonstd(ftx_message_t* msg, ftx_callsign_hash_interface_t* hash_if, const char* call_to, const char* call_de, const char* extra);
 
+/// Pack plain text, up to 13 characters
 ftx_message_rc_t ftx_message_encode_free(ftx_message_t* msg, const char* text);
 ftx_message_rc_t ftx_message_encode_telemetry(ftx_message_t* msg, const uint8_t* telemetry);
 

--- a/ft8/text.c
+++ b/ft8/text.c
@@ -2,21 +2,21 @@
 
 #include <string.h>
 
-const char* trim_front(const char* str)
+const char* trim_front(const char* str, char to_trim)
 {
-    // Skip leading whitespace
-    while (*str == ' ')
+    // Skip leading to_trim characters
+    while (*str == to_trim)
     {
         str++;
     }
     return str;
 }
 
-void trim_back(char* str)
+void trim_back(char* str, char to_trim)
 {
-    // Skip trailing whitespace by replacing it with '\0' characters
+    // Skip trailing to_trim characters by replacing them with '\0' characters
     int idx = strlen(str) - 1;
-    while (idx >= 0 && str[idx] == ' ')
+    while (idx >= 0 && str[idx] == to_trim)
     {
         str[idx--] = '\0';
     }
@@ -24,15 +24,23 @@ void trim_back(char* str)
 
 char* trim(char* str)
 {
-    str = (char*)trim_front(str);
-    trim_back(str);
+    str = (char*)trim_front(str, ' ');
+    trim_back(str, ' ');
+    // return a pointer to the first non-whitespace character
+    return str;
+}
+
+char* trim_brackets(char* str)
+{
+    str = (char*)trim_front(str, '<');
+    trim_back(str, '>');
     // return a pointer to the first non-whitespace character
     return str;
 }
 
 void trim_copy(char* trimmed, const char* str)
 {
-    str = (char*)trim_front(str);
+    str = (char*)trim_front(str, ' ');
     int len = strlen(str) - 1;
     while (len >= 0 && str[len] == ' ')
     {

--- a/ft8/text.c
+++ b/ft8/text.c
@@ -107,6 +107,7 @@ void fmtmsg(char* msg_out, const char* msg_in)
     *msg_out = 0; // Add zero termination
 }
 
+// Returns pointer to the null terminator within the given string (destination)
 char* append_string(char* string, const char* token)
 {
     while (*token != '\0')

--- a/ft8/text.c
+++ b/ft8/text.c
@@ -124,7 +124,7 @@ const char* copy_token(char* token, int length, const char* string)
     // Copy characters until a whitespace character or the end of string
     while (*string != ' ' && *string != '\0')
     {
-        if (length > 0)
+        if (length > 1)
         {
             *token = *string;
             token++;

--- a/ft8/text.h
+++ b/ft8/text.h
@@ -11,8 +11,8 @@ extern "C"
 
 // Utility functions for characters and strings
 
-const char* trim_front(const char* str);
-void trim_back(char* str);
+const char* trim_front(const char* str, char to_trim);
+void trim_back(char* str, char to_trim);
 
 /// In-place whitespace trim from front and back:
 /// 1) trims the back by changing whitespaces to '\0'
@@ -22,6 +22,12 @@ char* trim(char* str);
 
 /// Trim whitespace from start and end of string
 void trim_copy(char* trimmed, const char* str);
+
+/// In-place trim of <> characters from front and back:
+/// 1) trims the back by changing > to '\0'
+/// 2) trims the front by skipping <
+/// @return trimmed string (pointer to first non-whitespace character)
+char* trim_brackets(char* str);
 
 char to_upper(char c);
 bool is_digit(char c);

--- a/test/test.c
+++ b/test/test.c
@@ -269,6 +269,10 @@ int main()
              "<EA8/G5LSI> R2RFE RR73", &hash_if);
     test_msg("R2RFE/P EA8/G5LSI R+12", FTX_MESSAGE_TYPE_STANDARD,
              "R2RFE/P <EA8/G5LSI> R+12", &hash_if);
+    test_msg("TNX BOB 73 GL", FTX_MESSAGE_TYPE_FREE_TEXT,
+             "TNX BOB 73 GL", &hash_if); // message with 4 tokens must be free text
+    test_msg("TNX BOB 73", FTX_MESSAGE_TYPE_STANDARD,
+             "<TNX> <BOB> 73", &hash_if); // can't distinguish special callsigns from other tokens
 
     return 0;
 }

--- a/test/test.c
+++ b/test/test.c
@@ -238,8 +238,8 @@ int main()
 {
     // test1();
     // test4();
-    const char* callsigns[] = { "YL3JG", "W1A", "W1A/R", "W5AB", "W8ABC", "DE6ABC", "DE6ABC/R", "DE7AB", "DE9A", "3DA0X", "3DA0XYZ", "3DA0XYZ/R", "3XZ0AB", "3XZ0A" };
-    const char* tokens[] = { "CQ", "QRZ", /*"CQ_123", "CQ_000", "CQ_POTA", "CQ_SA", "CQ_O", "CQ_ASD" */ };
+    const char* callsigns[] = { "YL3JG", "W1A", "W1A/R", "W5AB", "W8ABC", "DE6ABC", "DE6ABC/R", "DE7AB", "DE9A", "3DA0X", "3DA0XYZ", "3DA0XYZ/R", "3XZ0AB", "3XZ0A", "CQ1CQ" };
+    const char* tokens[] = { "CQ", "QRZ", "CQ 123", "CQ 000", "CQ POTA", "CQ SA", "CQ O", "CQ ASD" };
     const ftx_field_t token_types[] = { FTX_FIELD_TOKEN, FTX_FIELD_TOKEN, FTX_FIELD_TOKEN_WITH_ARG, FTX_FIELD_TOKEN_WITH_ARG, FTX_FIELD_TOKEN_WITH_ARG, FTX_FIELD_TOKEN_WITH_ARG, FTX_FIELD_TOKEN_WITH_ARG, FTX_FIELD_TOKEN_WITH_ARG };
     const char* grids[] = { "KO26", "RR99", "AA00", "RR09", "AA01", "RRR", "RR73", "73", "R+10", "R+05", "R-12", "R-02", "+10", "+05", "-02", "-02", "" };
     const ftx_field_t grid_types[] = { FTX_FIELD_GRID, FTX_FIELD_GRID, FTX_FIELD_GRID, FTX_FIELD_GRID, FTX_FIELD_GRID, FTX_FIELD_TOKEN, FTX_FIELD_TOKEN, FTX_FIELD_TOKEN, FTX_FIELD_RST, FTX_FIELD_RST, FTX_FIELD_RST, FTX_FIELD_RST, FTX_FIELD_RST, FTX_FIELD_RST, FTX_FIELD_RST, FTX_FIELD_RST, FTX_FIELD_NONE };
@@ -273,6 +273,14 @@ int main()
              "TNX BOB 73 GL", &hash_if); // message with 4 tokens must be free text
     test_msg("TNX BOB 73", FTX_MESSAGE_TYPE_STANDARD,
              "<TNX> <BOB> 73", &hash_if); // can't distinguish special callsigns from other tokens
+    test_msg("CQ YL/LB2JK KO16sw", FTX_MESSAGE_TYPE_NONSTD_CALL,
+             "CQ YL/LB2JK", &hash_if); // grid not allowed with nonstandard call
+    test_msg("CQ POTA YL/LB2JK KO16sw", FTX_MESSAGE_TYPE_NONSTD_CALL,
+             "CQ YL/LB2JK", &hash_if); // CQ modifier not allowed with nonstandard call
+    test_msg("CQ JA LB2JK JO59", FTX_MESSAGE_TYPE_STANDARD,
+             "CQ JA LB2JK JO59", &hash_if);
+    test_msg("CQ 123 LB2JK JO59", FTX_MESSAGE_TYPE_STANDARD,
+             "CQ 123 LB2JK JO59", &hash_if);
 
     return 0;
 }


### PR DESCRIPTION
I've been testing by encoding wav files both with the test programs here and the ones from wsjt-x; also sending FT8 messages back and forth between my sbitx and zbitx radios with dummy loads; also doing on-the-air QSOs.

If I send a CQ with a non-standard callsign, and this message is received, then the recipient gets my non-standard callsign populated in his hashtable.  After that, a QSO is possible.  _But_ if I try to start a QSO without sending CQ first, the recipient will see only `<...>`.  So maybe I am still missing something about how to encode a type 4 message with the longer hash format.  Nevertheless, I think this PR is moving in a good direction; such a limitation can be fixed later when one of us figures out how.

I'll be in Jūrmala in August, so I wanted to make sure that I can operate with a prefix added to my callsign when I get there; also, it's a chance to get together in person, if you would like to meet.

Thanks for your work, which made it possible to operate FT8 in lightweight programs rather than big C++/fortran programs.